### PR TITLE
feat: Añadir modelos de solicitud para reanudar planes y leer recursos MCP

### DIFF
--- a/src/backend/common/models/messages_af.py
+++ b/src/backend/common/models/messages_af.py
@@ -332,6 +332,12 @@ class ChatMessageRequest(BaseModel):
     allow_plan: StrictBool = True
 
 
+class ResumePlanRequest(BaseModel):
+    """Request body for POST /api/v4/resume_plan."""
+
+    plan_id: str
+
+
 class ChatMessageResponse(BaseModel):
     """Response from the chat/message endpoint."""
 

--- a/src/backend/v4/api/router.py
+++ b/src/backend/v4/api/router.py
@@ -30,6 +30,7 @@ from common.models.messages_af import (
     InputTask,
     Plan,
     PlanStatus,
+    ResumePlanRequest,
     TeamAgent,
     TeamConfiguration,
     TeamSelectionRequest,
@@ -40,6 +41,11 @@ from common.utils.utils_af import (
     find_first_available_team,
     rai_success,
     rai_validate_team_config,
+)
+from v4.common.models.mcp_connection_models import (
+    McpReadResourceRequest,
+    MCPServerEntry,
+    MCPServerUpdateRequest,
 )
 from v4.common.services.plan_service import PlanService
 from v4.common.services.team_service import TeamService
@@ -91,7 +97,13 @@ def _extract_auth_with_token(request: Request) -> tuple:
 
 app_v4 = APIRouter(
     prefix="/api/v4",
-    responses={404: {"description": "Not found"}},
+    responses={
+        # FastAPI answers 400 "There was an error parsing the body" on
+        # malformed JSON for EVERY body-taking route — framework behavior,
+        # so the contract must declare it (schemathesis: UndefinedStatusCode).
+        400: {"description": "Malformed request body"},
+        404: {"description": "Not found"},
+    },
 )
 
 
@@ -4261,7 +4273,7 @@ async def notify_session_reauth(session_id: str, request: Request):
 @app_v4.post("/resume_plan")
 async def resume_plan(
     background_tasks: BackgroundTasks,
-    payload: dict,
+    payload: ResumePlanRequest,
     request: Request,
 ):
     """
@@ -4274,7 +4286,7 @@ async def resume_plan(
     run, which would create a duplicate plan.
     """
     user_id, tenant_id, user_access_token = _extract_auth_with_token(request)
-    plan_id = payload.get("plan_id", "")
+    plan_id = payload.plan_id
     if not plan_id:
         raise HTTPException(status_code=400, detail="plan_id is required")
 
@@ -5591,14 +5603,17 @@ async def discover_mcp_capabilities(
 
 
 @app_v4.post("/mcp/resources/read")
-async def read_mcp_resource(request: Request, user_id: str = Query(None)):
+async def read_mcp_resource(
+    body: McpReadResourceRequest,
+    user_id: str = Query(None),
+):
     """
     Read MCP UI Resource by URI.
 
     Supports MCP Protocol 2025-11-25 with ui:// scheme for widgets.
 
     Args:
-        request: FastAPI request with JSON body {"uri": "ui://..."}
+        body: JSON body with {"uri": "ui://..."}
         user_id: Optional user ID for auth context
 
     Returns:
@@ -5607,17 +5622,9 @@ async def read_mcp_resource(request: Request, user_id: str = Query(None)):
     try:
         from v4.common.services.mcp_resource_service import get_mcp_resource_service
 
-        # Parse request body
-        body = await request.json()
-        uri = body.get("uri")
+        uri = body.uri
 
-        if not uri:
-            raise HTTPException(status_code=400, detail="Missing 'uri' in request body")
-
-        # Get MCP resource service
         mcp_service = get_mcp_resource_service()
-
-        # Read resource from MCP server
         resource = await mcp_service.read_resource(uri)
 
         if not resource:
@@ -5717,18 +5724,14 @@ async def list_mcp_servers(request: Request):
 
 
 @app_v4.post("/mcp/connections/servers")
-async def register_mcp_server(request: Request):
+async def register_mcp_server(entry: MCPServerEntry, request: Request):
     """
     Register a new MCP server in the catalog.
 
     Body: MCPServerEntry fields (server_name, display_name, endpoint, etc.)
     """
     try:
-        from v4.common.models.mcp_connection_models import MCPServerEntry
         from v4.common.services.mcp_connections_service import MCPConnectionsService
-
-        body = await request.json()
-        entry = MCPServerEntry(**body)
 
         user_id, tenant_id = _extract_auth(request)
         entry.added_by = get_authenticated_user_details(
@@ -5762,7 +5765,9 @@ async def register_mcp_server(request: Request):
 
 
 @app_v4.put("/mcp/connections/servers/{server_id}")
-async def update_mcp_server(server_id: str, request: Request):
+async def update_mcp_server(
+    server_id: str, body: MCPServerUpdateRequest, request: Request
+):
     """
     Update an existing MCP server in the catalog.
 
@@ -5773,8 +5778,6 @@ async def update_mcp_server(server_id: str, request: Request):
     try:
         from v4.common.services.mcp_connections_service import MCPConnectionsService
 
-        body = await request.json()
-
         user_id, tenant_id = _extract_auth(request)
 
         svc = await MCPConnectionsService.get_instance()
@@ -5783,10 +5786,7 @@ async def update_mcp_server(server_id: str, request: Request):
         if not existing:
             raise HTTPException(status_code=404, detail="Server not found")
 
-        # Apply provided fields onto the existing entry. Never allow the body to
-        # change the document identity / partition metadata.
-        protected = {"id", "pk", "doc_type", "created_at"}
-        update_data = {k: v for k, v in body.items() if k not in protected}
+        update_data = body.model_dump(exclude_unset=True)
         existing = existing.model_copy(update=update_data)
 
         result = await svc.upsert_server(existing)

--- a/src/backend/v4/common/models/mcp_connection_models.py
+++ b/src/backend/v4/common/models/mcp_connection_models.py
@@ -294,3 +294,37 @@ class MCPUserConnection(BaseModel):
         default=2592000,  # 30 days in seconds
         description="Cosmos DB TTL for auto-cleanup of stale connections",
     )
+
+
+class McpReadResourceRequest(BaseModel):
+    """Request body for POST /api/v4/mcp/resources/read."""
+
+    uri: str
+
+
+class MCPServerUpdateRequest(BaseModel):
+    """Partial-update body for PUT /api/v4/mcp/connections/servers/{server_id}.
+
+    All fields are optional — only the provided ones are applied.
+    Identity / partition fields (id, pk, doc_type, created_at) are never
+    accepted from the client.
+    """
+
+    server_name: Optional[str] = None
+    display_name: Optional[str] = None
+    description: Optional[str] = None
+    icon_url: Optional[str] = None
+    endpoint: Optional[str] = None
+    transport: Optional[MCPTransportType] = None
+    auth_type: Optional[MCPAuthType] = None
+    credential_source: Optional[MCPCredentialSource] = None
+    audience: Optional[str] = None
+    auth_fields: Optional[List[str]] = None
+    oauth_scopes: Optional[List[str]] = None
+    oauth_authorize_url: Optional[str] = None
+    oauth_token_url: Optional[str] = None
+    oauth_client_id_env: Optional[str] = None
+    oauth_client_secret_env: Optional[str] = None
+    allowed_agents: Optional[List[str]] = None
+    enabled: Optional[bool] = None
+    tenant_id: Optional[str] = None


### PR DESCRIPTION
## Purpose
Add request models for resuming plans and reading MCP resources. This enhances the API by providing structured request bodies for these operations.

## Does this introduce a breaking change?
- [ ] Yes
- [ ] No

## How to Test
* Get the code
```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
```
```

## What to Check
Verify that the following are valid
* The new request models function correctly with the respective API endpoints.

## Other Information
No additional information is required.

